### PR TITLE
Updating Nokogiri gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '2.6.3'
+ruby '2.7.2'
 
 gem 'mechanize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
@@ -17,27 +17,27 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
-    mini_portile2 (2.4.0)
+    mime-types-data (3.2020.1104)
     net-http-digest_auth (1.4.1)
-    net-http-persistent (3.1.0)
+    net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
-    nokogiri (1.10.8)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
     ntlm-http (0.1.1)
+    racc (1.5.2)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
     webrobots (0.1.2)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-18
 
 DEPENDENCIES
   mechanize
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.7.2p137
 
 BUNDLED WITH
-   1.17.3
+   2.2.6

--- a/lib/crawler.rb
+++ b/lib/crawler.rb
@@ -51,7 +51,7 @@ class WebCrawler
           case scraped_url[0..4]
           when 'https' || 'http:' || 'ftp:/'
             save_site_crawl(scraped_url)
-            puts "Chacked: #{scraped_url}\n--------------------\n"
+            puts "Checked: #{scraped_url}\n--------------------\n"
           else
             url_split = url_to_crawl.split('/')
             if scraped_url[0] == '/'


### PR DESCRIPTION
**Remediation**

Upgrade nokogiri to version 1.11.0.rc4 or later. For example:
```ruby
gem "nokogiri", ">= 1.11.0.rc4"
```

Always verify the validity and compatibility of suggestions with your codebase.
**Details**
GHSA-vr8q-g5c7-m54m
_low severity_
Vulnerable versions: <= 1.10.10
Patched version: 1.11.0.rc4

**Severity**

Nokogiri maintainers have evaluated this as Low Severity (CVSS3 2.6).

**Description**

In Nokogiri versions <= 1.11.0.rc3, XML Schemas parsed by Nokogiri::XML::Schema are trusted by default, allowing external resources to be accessed over the network, potentially enabling XXE or SSRF attacks.

This behavior is counter to the security policy followed by Nokogiri maintainers, which is to treat all input as untrusted by default whenever possible.

Please note that this security fix was pushed into a new minor version, 1.11.x, rather than a patch release to the 1.10.x branch, because it is a breaking change for some schemas and the risk was assessed to be "Low Severity".
Affected Versions
```
Nokogiri <= 1.10.10 as well as prereleases 1.11.0.rc1, 1.11.0.rc2, and 1.11.0.rc3
```
**Mitigation**

There are no known workarounds for affected versions. Upgrade to Nokogiri 1.11.0.rc4 or later.

If, after upgrading to 1.11.0.rc4 or later, you wish to re-enable network access for resolution of external resources (i.e., return to the previous behavior):

    Ensure the input is trusted. Do not enable this option for untrusted input.
    When invoking the Nokogiri::XML::Schema constructor, pass as the second parameter an instance of Nokogiri::XML::ParseOptions with the NONET flag turned off.

So if your previous code was:
```
# in v1.11.0.rc3 and earlier, this call allows resources to be accessed over the network
# but in v1.11.0.rc4 and later, this call will disallow network access for external resources
schema = Nokogiri::XML::Schema.new(schema)
```
```
# in v1.11.0.rc4 and later, the following is equivalent to the code above
# (the second parameter is optional, and this demonstrates its default value)
schema = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA)
```
Then you can add the second parameter to indicate that the input is trusted by changing it to:
```
# in v1.11.0.rc3 and earlier, this would raise an ArgumentError 
# but in v1.11.0.rc4 and later, this allows resources to be accessed over the network
schema = Nokogiri::XML::Schema.new(trusted_schema, Nokogiri::XML::ParseOptions.new.nononet)
```

**References**

    This issue's public advisory
    Original Hackerone report (private)
    OWASP description of XXE attack
    OWASP description of SSRF attack

**Credit**

This vulnerability was independently reported by @eric-therond and @gucki.

The Nokogiri maintainers would like to thank HackerOne for providing a secure, responsible mechanism for reporting, and for providing their fantastic service to us.
