### PR TITLE
Updating Mechanize gem.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    mechanize (2.7.6)
+    mechanize (2.7.7)
       domain_name (~> 0.5, >= 0.5.1)
       http-cookie (~> 1.0)
       mime-types (>= 1.17.2)
@@ -14,6 +14,7 @@ GEM
       net-http-persistent (>= 2.5.2)
       nokogiri (~> 1.6)
       ntlm-http (~> 0.1, >= 0.1.1)
+      webrick (~> 1.7)
       webrobots (>= 0.0.9, < 0.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -28,6 +29,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    webrick (1.7.0)
     webrobots (0.1.2)
 
 PLATFORMS


### PR DESCRIPTION
**Bump mechanize from 2.7.6 to 2.7.7 dependencies**

_1 mechanize vulnerability found in Gemfile.lock 3 days ago_

**Remediation**

Upgrade mechanize to version 2.7.7 or later. For example:
```ruby
gem "mechanize", ">= 2.7.7"
```
Always verify the validity and compatibility of suggestions with your codebase.

**Details**

[GHSA-qrqm-fpv6-6r8g](https://github.com/advisories/GHSA-qrqm-fpv6-6r8g)
_low severity_
Vulnerable versions: >= 2.0.0, < 2.7.7
Patched version: 2.7.7

This security advisory has been created for public disclosure of a Command Injection vulnerability that was responsibly reported by @kyoshidajp (Katsuhiko YOSHIDA).

**Impact**

Mechanize >= v2.0, < v2.7.7 allows for OS commands to be injected using several classes' methods which implicitly use Ruby's Kernel.open method. Exploitation is possible only if untrusted input is used as a local filename and passed to any of these calls:

    Mechanize::CookieJar#load: since v2.0 (see 208e3ed)
    Mechanize::CookieJar#save_as: since v2.0 (see 5b776a4)
    Mechanize#download: since v2.2 (see dc91667)
    Mechanize::Download#save and #save! since v2.1 (see 98b2f51, bd62ff0)
    Mechanize::File#save and #save_as: since v2.1 (see 2bf7519)
    Mechanize::FileResponse#read_body: since v2.0 (see 01039f5)

**Patches**

These vulnerabilities are patched in Mechanize v2.7.7.

**Workarounds**

No workarounds are available. We recommend upgrading to v2.7.7 or later.

**References**

See https://docs.rubocop.org/rubocop/cops_security.html#securityopen for background on why Kernel.open should not be used with untrusted input.
For more information

If you have any questions or comments about this advisory, please open an issue in sparklemotion/mechanize.
